### PR TITLE
Fix for boolean rendered as string

### DIFF
--- a/jsx.parser.js
+++ b/jsx.parser.js
@@ -18,7 +18,9 @@ module.exports = (tokens, opts={})=>{
 				key = last;
 				last = null;
 			}else if(key && token.type == 'code'){
-				if(opts.useEval){
+				if (token.value.match(/^(?:tru|fals)e$/)) {
+					props[key] = token.value === 'true';
+				}else if(opts.useEval){
 					props[key] = eval(`(()=>{ return ${token.value}})()`);
 				}else{
 					props[key] = token.value;


### PR DESCRIPTION
When the attribute value is boolean, the parse is returning as string. For ex, the below jsx returns render:'true'. This fix check the value using regex and set the boolean type.

`<div render={true}></div>`